### PR TITLE
Cleanup deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,39 +74,6 @@ assert.noFile = function () {
 };
 
 /**
- * Assert that each of an array of files exists. If an item is an array with
- * the first element a filepath and the second element a regex, check to see
- * that the file content matches the regex
- *
- * @deprecated
- * @param {Array} pairs - an array of paths to files or file/regex subarrays
- *
- * @example
- * file(['templates/user.hbs', 'templates/user/edit.hbs']);
- *
- * @example
- * files(['foo.js', 'bar.js', ['baz.js', /function baz/]]);
- */
-
-assert.files = function (files) {
-  var depMsg = 'assert.files deprecated. Use ';
-  depMsg += 'assert.file([String, String, ...]) or ';
-  depMsg += 'assert.file([[String, RegExp], [String, RegExp]...]) instead.';
-  deprecate(depMsg);
-  files.forEach(function (item) {
-    var file = item;
-    var rx;
-    if (item instanceof Array) {
-      file = item[0];
-      rx = item[1];
-      assert.fileContent(file, rx);
-    } else {
-      assert.file(file);
-    }
-  });
-};
-
-/**
  * Assert that a file's content matches a regex or string
  * @param  {String}       file     - path to a file
  * @param  {Regex|String} reg      - regex / string that will be used to search the file

--- a/index.js
+++ b/index.js
@@ -39,31 +39,15 @@ var assert = module.exports = require('assert');
  * @param {Array}         paths    - an array of paths to files
  * @example
  * assert.file(['templates/user.hbs', 'templates/user/edit.hbs']);
- *
- * @also
- *
- * Assert that a file's content matches a regex
- * @deprecated
- * @param  {String}       path     - path to a file
- * @param  {Regex}        reg      - regex that will be used to search the file
- * @example
- * assert.file('models/user.js', /App\.User = DS\.Model\.extend/);
  */
 
 assert.file = function () {
   var args = _.toArray(arguments);
-  if (_.last(args) instanceof RegExp) {  // DEPRECATED CASE
-    var depMsg = 'assert.file(String, RegExp) DEPRECATED; use ';
-    depMsg += 'assert.fileContent(String, RegExp) instead.';
-    deprecate(depMsg);
-    assert.fileContent(args[0], args[1]);
-  } else {
-    args = _.isString(args[0]) ? args : args[0];
-    args.forEach(function (file) {
-      var here = fs.existsSync(file);
-      assert.ok(here, file + ', no such file or directory');
-    });
-  }
+  args = _.isString(args[0]) ? args : args[0];
+  args.forEach(function (file) {
+    var here = fs.existsSync(file);
+    assert.ok(here, file + ', no such file or directory');
+  });
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -12,11 +12,6 @@
 
 var fs = require('fs');
 var _ = require('lodash');
-var chalk = require('chalk');
-
-function deprecate (message) {
-  console.log(chalk.yellow('(!) ') + message);
-}
 
 function extractMethods(methods) {
   return _.isArray(methods) ? methods : Object.keys(methods).filter(function (method) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test": "jshint *.js && jscs *.js && mocha"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
     "lodash": "^3.6.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -53,34 +53,6 @@ describe('generators.assert', function () {
     });
   });
 
-  describe('.files()', function () {  // DEPRECATED
-    it('accept an array of files all of which exist', function () {
-      assert.doesNotThrow(
-        yoAssert.files.bind(yoAssert, ['testFile', 'testFile2']));
-    });
-
-    it('reject an array of multiple files one of which exists', function () {
-      assert.throws(
-        yoAssert.files.bind(yoAssert, ['testFile', 'etherealTestFile']));
-    });
-
-    it('accept an array of file/regex pairs when each file\'s content matches the corresponding regex', function () {
-      var arg = [
-        ['testFile', /Roses are red/],
-        ['testFile2', /Violets are blue/]
-      ];
-      assert.doesNotThrow(yoAssert.files.bind(yoAssert, arg));
-    });
-
-    it('reject an array of file/regex pairs when one file\'s content does not matches the corresponding regex', function () {
-      var arg = [
-        ['testFile', /Roses are red/],
-        ['testFile2', /Violets are orange/]
-      ];
-      assert.throws(yoAssert.files.bind(yoAssert, arg));
-    });
-  });
-
   describe('.fileContent()', function () {
     it('accept a file and regex when the file content matches the regex', function () {
       assert.doesNotThrow(yoAssert.fileContent.bind(yoAssert, 'testFile', /Roses are red/));

--- a/test.js
+++ b/test.js
@@ -31,16 +31,6 @@ describe('generators.assert', function () {
     it('reject multiple files one of which does not exist', function () {
       assert.throws(yoAssert.file.bind(yoAssert, ['testFile', 'intangibleTestFile']));
     });
-
-    // DEPRECATED
-
-    it('accept a file with content that matches reg', function () {
-      assert.doesNotThrow(yoAssert.file.bind(yoAssert, 'testFile', /Roses are red/));
-    });
-
-    it('reject a file with content does not match reg', function () {
-      assert.throws(yoAssert.file.bind(yoAssert, 'testFile', /Roses are blue/));
-    });
   });
 
   describe('.noFile()', function () {


### PR DESCRIPTION
This PR removes the deprecated method `assert.files` and the deprecated api for `assert.file`.