### PR TITLE
Using `jsonFileContent` instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ assert.objectContent = function (obj, content) {
  * @param {Object} content An object of key/values the file should contains
  */
 
-assert.JSONFileContent = function (filename, content) {
+assert.JSONFileContent = assert.jsonFileContent = function (filename, content) {
   var obj = JSON.parse(fs.readFileSync(filename, 'utf8'));
   assert.objectContent(obj, content);
 };

--- a/test.js
+++ b/test.js
@@ -209,30 +209,30 @@ describe('yeoman-assert', function () {
     });
   });
 
-  describe('.JSONFileContent()', function () {
+  describe('.jsonFileContent()', function () {
     var file = path.join(__dirname, 'fixtures/dummy.json');
 
     it('pass if file contains the keys', function () {
-      assert.doesNotThrow(yoAssert.JSONFileContent.bind(yoAssert, file, {
+      assert.doesNotThrow(yoAssert.jsonFileContent.bind(yoAssert, file, {
         a: { b: 1 },
         b: [1, 2]
       }));
     });
 
     it('fails if file does not contain the keys', function () {
-      assert.throws(yoAssert.JSONFileContent.bind(yoAssert, file, {
+      assert.throws(yoAssert.jsonFileContent.bind(yoAssert, file, {
         a: { b: 1 },
         b: 'a'
       }));
 
-      assert.throws(yoAssert.JSONFileContent.bind(yoAssert, file, {
+      assert.throws(yoAssert.jsonFileContent.bind(yoAssert, file, {
         a: { b: 3 },
         b: [1]
       }));
     });
 
     it('fails if file does not exists', function () {
-      assert.throws(yoAssert.JSONFileContent.bind(yoAssert, 'does-not-exist', {}));
+      assert.throws(yoAssert.jsonFileContent.bind(yoAssert, 'does-not-exist', {}));
     });
   });
 });


### PR DESCRIPTION
WRT [this](https://github.com/yeoman/generator-node/pull/198#discussion_r46865046) comment.

Should we provide a depreciate warning? (Considering this is a pretty new API, rename must not impact?) 