### PR TITLE
fix aliasing for (no)jsonFileContent aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ assert.JSONFileContent = assert.jsonFileContent = function (filename, content) {
  * @param {Object} content An object of key/values the file should not contain
  */
 
-assert.JSONFileContent = assert.noJsonFileContent = function (filename, content) {
+assert.noJSONFileContent = assert.noJsonFileContent = function (filename, content) {
   var obj = JSON.parse(fs.readFileSync(filename, 'utf8'));
   assert.noObjectContent(obj, content);
 };

--- a/test.js
+++ b/test.js
@@ -254,6 +254,10 @@ describe('yeoman-assert', function () {
   describe('.jsonFileContent()', function () {
     var file = path.join(__dirname, 'fixtures/dummy.json');
 
+    it('is aliased to .JSONFileContent()', function () {
+      assert(yoAssert.jsonFileContent === yoAssert.JSONFileContent);
+    });
+
     it('pass if file contains the keys', function () {
       assert.doesNotThrow(yoAssert.jsonFileContent.bind(yoAssert, file, {
         a: {b: 1},
@@ -280,6 +284,10 @@ describe('yeoman-assert', function () {
 
   describe('.noJsonFileContent()', function () {
     var file = path.join(__dirname, 'fixtures/dummy.json');
+
+    it('is aliased to .noJSONFileContent()', function () {
+      assert(yoAssert.noJsonFileContent === yoAssert.noJSONFileContent);
+    });
 
     it('fails if file contains the keys', function () {
       assert.throws(yoAssert.noJsonFileContent.bind(yoAssert, file, {


### PR DESCRIPTION
There was a little copy/paste error with the new jsonFileContent and noJsonFileContent assertions that was breaking backwards-compatibility. I've fixed it, and added two little tests to check that the aliases are pointing the right way.