### PR TITLE
Adding assert.equalsFileContent

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,36 @@ assert.fileContent = function () {
 };
 
 /**
+ * Assert that a file's content is the same as the given string
+ * @param {String}  file            - path to a file
+ * @param {String}  expectedContent - the expected content of the file
+ * @example
+ * assert.equalsFileContent(
+ *   'data.js',
+ *   'const greeting = "Hello";\nexport default { greeting }'
+ * );
+ *
+ * @also
+ *
+ * Assert that each file in an array of file-string pairs equals its corresponding string
+ * @param {Array}   pairs           - an array of arrays, where each subarray is a [String, String] pair
+ * @example
+ * assert.equalsFileContent([
+ *   ['data.js', 'const greeting = "Hello";\nexport default { greeting }'],
+ *   ['user.js', 'export default {\n  name: 'Coleman',\n  age: 0\n}']
+ * ]);
+ */
+
+assert.equalsFileContent = function () {
+  convertArgs(arguments).forEach(pair => {
+    const file = pair[0];
+    const expectedContent = pair[1];
+    assert.file(file);
+    this.textEqual(readFile(file), expectedContent);
+  });
+};
+
+/**
  * Assert that a file's content does not match a regex / string
  * @param {String}       file     - path to a file
  * @param {Regex|String} reg      - regex / string that will be used to search the file

--- a/test.js
+++ b/test.js
@@ -86,6 +86,32 @@ describe('yeoman-assert', () => {
     });
   });
 
+  describe('.equalsFileContent()', () => {
+    it('accept a file and string when the file content equals the string', () => {
+      assert.doesNotThrow(yoAssert.equalsFileContent.bind(yoAssert, 'testFile', 'Roses are red.\n'));
+    });
+
+    it('reject a file and string when the file content does not equal the string', () => {
+      assert.throws(yoAssert.equalsFileContent.bind(yoAssert, 'testFile', 'Roses are red'));
+    });
+
+    it('accept an array of file/string pairs when each file\'s content equals the corresponding string', () => {
+      const arg = [
+        ['testFile', 'Roses are red.\n'],
+        ['testFile2', 'Violets are blue.\n']
+      ];
+      assert.doesNotThrow(yoAssert.equalsFileContent.bind(yoAssert, arg));
+    });
+
+    it('reject an array of file/string pairs when one file\'s content does not equal the corresponding string', () => {
+      const arg = [
+        ['testFile', 'Roses are red.\n'],
+        ['testFile2', 'Violets are green.\n']
+      ];
+      assert.throws(yoAssert.equalsFileContent.bind(yoAssert, arg));
+    });
+  });
+
   describe('.noFileContent()', () => {
     it('accept a file and regex when the file content does not match the regex', () => {
       assert.doesNotThrow(yoAssert.noFileContent.bind(yoAssert, 'testFile', /Roses are blue/));


### PR DESCRIPTION
To assert that a file's content is the same as the given string

(Fixes #23)